### PR TITLE
hyogo_v2.7.2 update

### DIFF
--- a/app/controllers/settings/profiles_controller.rb
+++ b/app/controllers/settings/profiles_controller.rb
@@ -28,7 +28,7 @@ class Settings::ProfilesController < Settings::BaseController
   private
 
   def account_params
-    params.require(:account).permit(:display_name, :note, :avatar, :header, :locked,:area, :bot, :discoverable, fields_attributes: [:name, :value])
+    params.require(:account).permit(:display_name, :note, :avatar, :header, :locked, :area, :bot, :discoverable, fields_attributes: [:name, :value])
   end
 
   def set_account

--- a/app/javascript/area_settings.json
+++ b/app/javascript/area_settings.json
@@ -204,10 +204,8 @@
         "mastodon.nara.jp",
         "mastodon.wakayama.jp",
         "mastodos.com",
-        "miestodon.com",
         "don.akashi.cloud",
-        "akashiensis.com",
-        "shigadon.com"
+        "akashiensis.com"
       ]
     },
     {

--- a/app/javascript/area_settings.json
+++ b/app/javascript/area_settings.json
@@ -87,12 +87,6 @@
       "instance-eng-name": "remote-mastodos"
     },
 
-    "myd.kyoto.jp": {
-      "instance-name": "京都丼",
-      "instance-short-name": "京",
-      "instance-eng-name": "remote-kyoto"
-    },
-
     "pawoo.net": {
       "instance-name": "パゥー",
       "instance-short-name": "PW",

--- a/app/javascript/area_settings.json
+++ b/app/javascript/area_settings.json
@@ -58,126 +58,108 @@
 "instances":
   {
     "mstdn.osaka": {
-      "instance-id": 1,
       "instance-name": "大阪丼",
       "instance-short-name": "大",
       "instance-eng-name": "remote-osaka"
     },
 
     "biwakodon.com": {
-      "instance-id": 2,
       "instance-name": "琵琶湖丼",
       "instance-short-name": "琵",
       "instance-eng-name": "remote-biwako"
     },
 
     "mastodon.nara.jp": {
-      "instance-id": 3,
       "instance-name": "鹿トドン",
       "instance-short-name": "鹿",
       "instance-eng-name": "remote-nara"
     },
 
     "mastodon.wakayama.jp": {
-      "instance-id": 4,
       "instance-name": "和歌山丼",
       "instance-short-name": "和",
       "instance-eng-name": "remote-wakayama"
     },
 
     "mastodos.com": {
-      "instance-id": 5,
       "instance-name": "マストどす",
       "instance-short-name": "ど",
       "instance-eng-name": "remote-mastodos"
     },
 
     "miestodon.com": {
-      "instance-id": 6,
       "instance-name": "三重スト丼",
       "instance-short-name": "三",
       "instance-eng-name": "remote-mie"
     },
 
     "myd.kyoto.jp": {
-      "instance-id": 7,
       "instance-name": "京都丼",
       "instance-short-name": "京",
       "instance-eng-name": "remote-kyoto"
     },
 
     "pawoo.net": {
-      "instance-id": 8,
       "instance-name": "パゥー",
       "instance-short-name": "PW",
       "instance-eng-name": "remote-pawoo"
     },
 
     "mstdn.jp": {
-      "instance-id": 9,
       "instance-name": ".jp",
       "instance-short-name": "JP",
       "instance-eng-name": "remote-jp"
     },
 
     "friends.nico": {
-      "instance-id": 10,
       "instance-name": "ニコ",
       "instance-short-name": "NC",
       "instance-eng-name": "remote-nico"
     },
 
     "mastodon.social": {
-      "instance-id": 11,
       "instance-name": "social",
       "instance-short-name": "SC",
       "instance-eng-name": "remote-social"
     },
 
     "nishinomiya.in.net": {
-      "instance-id": 12,
       "instance-name": "西宮",
       "instance-short-name": "宮",
       "instance-eng-name": "remote-nishinomiya"
     },
 
     "don.akashi.cloud": {
-      "instance-id": 13,
       "instance-name": "明石丼",
       "instance-short-name": "明",
       "instance-eng-name": "remote-akashidon"
     },
 
     "akashiensis.com": {
-      "instance-id": 14,
       "instance-name": "AKASHIensis",
       "instance-short-name": "石",
       "instance-eng-name": "remote-akashiensis"
     },
 
     "shigadon.com": {
-      "instance-id": 15,
       "instance-name": "滋賀丼",
       "instance-short-name": "滋",
       "instance-eng-name": "remote-shigadon"
     },
 
     "knzk.me": {
-      "instance-id": 16,
       "instance-name": "神崎丼",
       "instance-short-name": "兄",
       "instance-eng-name": "remote-kanzaki"
     },
 
     "mstdn.maud.io": {
-      "instance-id": 17,
       "instance-name": "末代鯖",
       "instance-short-name": "代",
       "instance-eng-name": "remote-matsudai"
     },
 
     "mstdn-workers.com": {
-      "instance-id": 18,
       "instance-name": "社畜丼",
       "instance-short-name": "畜",
       "instance-eng-name": "remote-shachiku"

--- a/app/javascript/area_settings.json
+++ b/app/javascript/area_settings.json
@@ -87,12 +87,6 @@
       "instance-eng-name": "remote-mastodos"
     },
 
-    "miestodon.com": {
-      "instance-name": "三重スト丼",
-      "instance-short-name": "三",
-      "instance-eng-name": "remote-mie"
-    },
-
     "myd.kyoto.jp": {
       "instance-name": "京都丼",
       "instance-short-name": "京",

--- a/app/javascript/area_settings.json
+++ b/app/javascript/area_settings.json
@@ -51,7 +51,7 @@
     {
       "area-id": 8,
       "area-name": "県外",
-      "area-short-name": "外",
+      "area-short-name": "他",
       "area-eng-name": "kengai"
     }
   ],

--- a/app/javascript/area_settings.json
+++ b/app/javascript/area_settings.json
@@ -111,12 +111,6 @@
       "instance-eng-name": "remote-social"
     },
 
-    "nishinomiya.in.net": {
-      "instance-name": "西宮",
-      "instance-short-name": "宮",
-      "instance-eng-name": "remote-nishinomiya"
-    },
-
     "don.akashi.cloud": {
       "instance-name": "明石丼",
       "instance-short-name": "明",

--- a/app/javascript/mastodon/components/status.js
+++ b/app/javascript/mastodon/components/status.js
@@ -302,7 +302,7 @@ class Status extends ImmutablePureComponent {
               <a onClick={this.handleAccountClick} target='_blank' data-id={status.getIn(['account', 'id'])} href={status.getIn(['account', 'url'])} title={status.getIn(['account', 'acct'])} className='status__display-name'>
                 <div className='status__avatar'>
                   {statusAvatar}
-              {statusAreaAvatar}
+                  {statusAreaAvatar}
                 </div>
 
                 <DisplayName account={status.get('account')} others={otherAccounts} />

--- a/app/javascript/mastodon/features/area_timeline/components/column_settings.js
+++ b/app/javascript/mastodon/features/area_timeline/components/column_settings.js
@@ -41,11 +41,6 @@ class ColumnSettings extends React.PureComponent {
         <div className='column-settings__row'>
           <SettingSelect settings={settings} settingKey={['area', 'body']} onChange={onChange} groups={areas}/>
         </div>
-        <span className='column-settings__section'><FormattedMessage id='home.column_settings.advanced' defaultMessage='Advanced' /></span>
-
-        <div className='column-settings__row'>
-          <SettingText prefix='area_timeline' settings={settings} settingKey={['regex', 'body']} onChange={onChange} label={intl.formatMessage(messages.filter_regex)} />
-        </div>
       </div>
     );
   }

--- a/app/javascript/mastodon/features/area_timeline/components/column_settings.js
+++ b/app/javascript/mastodon/features/area_timeline/components/column_settings.js
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { defineMessages, injectIntl, FormattedMessage } from 'react-intl';
 import SettingSelect from '../../../components/setting_select';
-import SettingText from '../../../components/setting_text';
 
 const messages = defineMessages({
-  filter_regex: { id: 'home.column_settings.filter_regex', defaultMessage: 'Filter out by regular expressions' },
   filter_area: { id: 'area.column_settings.filter_area', defaultMessage: 'Filter out by area' },
   settings: { id: 'area.settings', defaultMessage: 'Column settings' },
 });

--- a/app/javascript/mastodon/reducers/settings.js
+++ b/app/javascript/mastodon/reducers/settings.js
@@ -77,9 +77,6 @@ const initialState = ImmutableMap({
   }),
 
   area: ImmutableMap({
-    regex: ImmutableMap({
-      body: '',
-    }),
     area: ImmutableMap({
       body: 'kansai',
     }),

--- a/app/javascript/styles/custom.scss
+++ b/app/javascript/styles/custom.scss
@@ -105,14 +105,6 @@
     @include header__remote__1kanji__area();
 }
 
-.account__header__area-remote-mie{
-    @include header__remote__1kanji__area();
-}
-
-.account__header__area-remote-kyoto{
-    @include header__remote__1kanji__area();
-}
-
 .account__header__area-remote-pawoo{
     @include header__2eng__area();
     background-color: rgba(200,200,200,0.9);
@@ -135,10 +127,6 @@
     @include header__2eng__area();
     background-color: rgba(200,200,200,0.9);
     color:#000000;
-}
-
-.account__header__area-remote-nishinomiya{
-    @include header__remote__1kanji__area();
 }
 
 .account__header__area-remote-akashidon{
@@ -270,14 +258,6 @@
     @include avatar__area__remote_1kanji();
 }
 
-.account__avatar__area-remote-mie{
-    @include avatar__area__remote_1kanji();
-}
-
-.account__avatar__area-remote-kyoto{
-    @include avatar__area__remote_1kanji();
-}
-
 .account__avatar__area-remote-pawoo{
     @include avatar__2eng__area();
     margin: 0px 0px 0px -4px;
@@ -304,10 +284,6 @@
     margin: 0px;
     background-color: rgba(200,200,200,0.9);
     color:#000000;
-}
-
-.account__avatar__area-remote-nishinomiya{
-    @include avatar__area__remote_1kanji();
 }
 
 .account__avatar__area-remote-akashidon{


### PR DESCRIPTION
### Remove
- ホームタイムライン等から正規表現でのフィルターが削除されたことに伴い、地域タイムラインからも正規表現フィルターを削除
- リモートインスタンスの表示から以下を削除
  - 三重スト丼: miestodon.com
  - 京都丼: myd.kyoto.jp
  - 西宮丼: nishinomiya.in.net
- 関西タイムラインの対象から以下を削除
  - 三重スト丼: miestodon.com
  - 滋賀丼: shigadon.com

### Change
- 地域表示「県外」の短縮表示を「外」から「他」に変更

### Fix
- コード中のインデントや空白など細かな修正

### Notice
- v2.7.2を名乗っていますが、本体のmastodonは更新されておらず、v2.7.1です