### PR TITLE
Fix placement of user locale icon overlay

### DIFF
--- a/app/javascript/styles/contrast.scss
+++ b/app/javascript/styles/contrast.scss
@@ -1,3 +1,4 @@
 @import 'contrast/variables';
 @import 'application';
 @import 'contrast/diff';
+@import 'custom';

--- a/app/javascript/styles/mastodon-light.scss
+++ b/app/javascript/styles/mastodon-light.scss
@@ -1,3 +1,4 @@
 @import 'mastodon-light/variables';
 @import 'application';
 @import 'mastodon-light/diff';
+@import 'custom';


### PR DESCRIPTION
## Description

-   ライトモードと、ハイコントラストモードで地域表示がズレる問題を解消

## Issue

-   resolved #1145

## Fixed screenshots

| ライト                                                                                                          | ハイコントラスト                                                                                                | ダーク                                                                                                          |
| --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
| ![image](https://user-images.githubusercontent.com/33796432/214036959-18132759-23f8-4051-907c-938955c6ce84.png) | ![image](https://user-images.githubusercontent.com/33796432/214036971-a7fa5a55-3941-44cb-abcc-f97782a2951c.png) | ![image](https://user-images.githubusercontent.com/33796432/214036982-8ac32fd1-b4cf-45d7-9e21-1db3cebc802c.png) |