### PR TITLE
Separate fork-specific Docker Compose config to override file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,7 +69,7 @@ yarn-debug.log
 *-cloudimg-console.log
 
 # Ignore Docker option files
-docker-compose.override.yml
+# docker-compose.override.yml is now tracked in the repository for fork-specific config
 
 dist/local/ssl
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,6 +222,19 @@ docker compose up -d
 - Streaming API: http://localhost:4000
 - Elasticsearch (if enabled): http://localhost:9200
 
+### Fork-Specific Docker Configuration
+
+This fork uses Docker Compose's override file mechanism to manage fork-specific image tags:
+
+- `docker-compose.yml` - Base configuration compatible with upstream Mastodon
+- `docker-compose.override.yml` - Fork-specific image tags (e.g., `ghcr.io/pinfort/mastodon:hyogo_v4.3.4_v4.3.9`)
+
+The override file is automatically applied when running `docker compose` commands. This separation prevents merge conflicts during upstream syncs, as the base `docker-compose.yml` can accept upstream changes while `docker-compose.override.yml` preserves fork customizations.
+
+**When syncing with upstream:**
+- Accept upstream changes to `docker-compose.yml`
+- Always preserve `docker-compose.override.yml` with fork-specific image tags
+
 ### Docker Commands Reference
 
 **Container management:**
@@ -610,7 +623,8 @@ Conflicts are common due to fork-specific changes. Focus on preserving custom fe
 - `app/javascript/area_settings.json` - Fork-specific, keep your version
 - `app/models/area_feed.rb` - Fork-specific, keep your version
 - Routes with `/areas/*` patterns - Preserve fork additions
-- `docker-compose.yml` - Fork-specific configuration, carefully merge
+- `docker-compose.yml` - Accept upstream version (fork-specific config is in docker-compose.override.yml)
+- `docker-compose.override.yml` - Fork-specific image tags, keep your version
 - Database migrations - May need careful ordering
 
 **Conflict Resolution Strategy:**
@@ -634,6 +648,7 @@ nano path/to/file  # Manually resolve conflicts
 
 - `app/javascript/area_settings.json` - Always keep fork version
 - `app/models/area_feed.rb` - Fork-specific model
+- `docker-compose.override.yml` - Fork-specific Docker image tags
 - Controllers/routes for area timelines - Preserve fork logic
 - Any files with "hyogo" or "area" in the name
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -232,6 +232,7 @@ This fork uses Docker Compose's override file mechanism to manage fork-specific 
 The override file is automatically applied when running `docker compose` commands. This separation prevents merge conflicts during upstream syncs, as the base `docker-compose.yml` can accept upstream changes while `docker-compose.override.yml` preserves fork customizations.
 
 **When syncing with upstream:**
+
 - Accept upstream changes to `docker-compose.yml`
 - Always preserve `docker-compose.override.yml` with fork-specific image tags
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,11 +1,9 @@
 # Fork-specific Docker Compose override configuration
-# Copy this file to docker-compose.override.yml to use Hyogo fork images
-#
-# Usage:
-#   cp docker-compose.override.yml.sample docker-compose.override.yml
-#   docker compose up -d
+# This file is tracked in the repository and provides fork-specific image tags
 #
 # This separation prevents merge conflicts when syncing with upstream Mastodon
+# Docker Compose automatically applies this override file when you run:
+#   docker compose up -d
 
 services:
   web:

--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -1,0 +1,18 @@
+# Fork-specific Docker Compose override configuration
+# Copy this file to docker-compose.override.yml to use Hyogo fork images
+#
+# Usage:
+#   cp docker-compose.override.yml.sample docker-compose.override.yml
+#   docker compose up -d
+#
+# This separation prevents merge conflicts when syncing with upstream Mastodon
+
+services:
+  web:
+    image: ghcr.io/pinfort/mastodon:hyogo_v4.3.4_v4.3.9
+
+  streaming:
+    image: ghcr.io/pinfort/mastodon-streaming:hyogo_v4.3.4_v4.3.9
+
+  sidekiq:
+    image: ghcr.io/pinfort/mastodon:hyogo_v4.3.4_v4.3.9

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
 
   web:
     build: .
-    image: ghcr.io/pinfort/mastodon:hyogo_v4.3.4_v4.3.9
+    image: ghcr.io/mastodon/mastodon:latest
     restart: always
     env_file: .env.production
     command: bundle exec puma -C config/puma.rb
@@ -79,7 +79,7 @@ services:
 
   streaming:
     build: .
-    image: ghcr.io/pinfort/mastodon-streaming:hyogo_v4.3.4_v4.3.9
+    image: ghcr.io/mastodon/mastodon-streaming:latest
     restart: always
     env_file: .env.production
     command: node ./streaming/index.js
@@ -97,7 +97,7 @@ services:
 
   sidekiq:
     build: .
-    image: ghcr.io/pinfort/mastodon:hyogo_v4.3.4_v4.3.9
+    image: ghcr.io/mastodon/mastodon:latest
     restart: always
     env_file: .env.production
     command: bundle exec sidekiq -c 5


### PR DESCRIPTION
Fixes #1193

This PR separates fork-specific Docker Compose configurations to prevent merge conflicts during upstream syncs.

### Changes

- Created `docker-compose.override.yml` with fork-specific image tags
- Updated `docker-compose.yml` to use upstream Mastodon image references
- This allows the base file to remain compatible with upstream while preserving fork customizations

Generated with [Claude Code](https://claude.ai/code)