### PR TITLE
Remove mstdn.osaka from instance configuration

### DIFF
--- a/app/javascript/area_settings.json
+++ b/app/javascript/area_settings.json
@@ -56,12 +56,6 @@
     }
   ],
   "instances": {
-    "mstdn.osaka": {
-      "instance-name": "大阪丼",
-      "instance-short-name": "大",
-      "instance-eng-name": "remote-osaka"
-    },
-
     "mastodos.com": {
       "instance-name": "マストどす",
       "instance-short-name": "ど",
@@ -131,7 +125,7 @@
     {
       "group_name": "kansai",
       "group_id": 1,
-      "instances": [null, "mstdn.osaka", "mastodos.com", "minohdon.jp"]
+      "instances": [null, "mastodos.com", "minohdon.jp"]
     },
     {
       "group_name": "bestfriends",

--- a/app/javascript/styles/custom.scss
+++ b/app/javascript/styles/custom.scss
@@ -97,10 +97,6 @@
   color: #000000;
 }
 
-.account__header__area-remote-osaka {
-  @include header-remote-1kanji-area;
-}
-
 .account__header__area-remote-mastodos {
   @include header-remote-1kanji-area;
 }
@@ -252,10 +248,6 @@
 
   background-color: rgba(200, 200, 200, 90%);
   color: #000000;
-}
-
-.account__avatar__area-remote-osaka {
-  @include avatar-area-remote-1kanji;
 }
 
 .account__avatar__area-remote-mastodos {


### PR DESCRIPTION
### Summary

Removes the unavailable instance mstdn.osaka from all configuration files:
- Instance definitions in area_settings.json
- Kansai area group configuration
- CSS styling rules for remote-osaka

The instance mstdn.osaka is no longer available, so this keeps the configuration up to date.

Fixes #1195

---

Generated with [Claude Code](https://claude.ai/code)