### PR TITLE
Remove CSS rules for remote-osaka

### DIFF
--- a/app/javascript/styles/custom.scss
+++ b/app/javascript/styles/custom.scss
@@ -97,10 +97,6 @@
   color: #000000;
 }
 
-.account__header__area-remote-osaka {
-  @include header-remote-1kanji-area;
-}
-
 .account__header__area-remote-mastodos {
   @include header-remote-1kanji-area;
 }
@@ -252,10 +248,6 @@
 
   background-color: rgba(200, 200, 200, 90%);
   color: #000000;
-}
-
-.account__avatar__area-remote-osaka {
-  @include avatar-area-remote-1kanji;
 }
 
 .account__avatar__area-remote-mastodos {


### PR DESCRIPTION
### Summary

Removes the unavailable instance mstdn.osaka from all configuration files:
- Instance definitions in area_settings.json
- Kansai area group configuration
- CSS styling rules for remote-osaka

The instance mstdn.osaka is no longer available, so this keeps the configuration up to date.

Fixes #1195

---

Generated with [Claude Code](https://claude.ai/code)