### PR TITLE
fix overriding for docker compose file

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -11,12 +11,12 @@ services:
 
   web:
     image: ghcr.io/pinfort/mastodon:hyogo_v4.4.0_v4.4.1
-    depends_on: []
+    depends_on: !reset []
 
   streaming:
     image: ghcr.io/pinfort/mastodon-streaming:hyogo_v4.4.0_v4.4.1
-    depends_on: []
+    depends_on: !reset []
 
   sidekiq:
     image: ghcr.io/pinfort/mastodon:hyogo_v4.4.0_v4.4.1
-    depends_on: []
+    depends_on: !reset []

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -6,11 +6,17 @@
 #   docker compose up -d
 
 services:
+  db: !reset null # prd uses database outside of docker
+  redis: !reset null # prd uses redis outside of docker
+
   web:
     image: ghcr.io/pinfort/mastodon:hyogo_v4.4.0_v4.4.1
+    depends_on: []
 
   streaming:
     image: ghcr.io/pinfort/mastodon-streaming:hyogo_v4.4.0_v4.4.1
+    depends_on: []
 
   sidekiq:
     image: ghcr.io/pinfort/mastodon:hyogo_v4.4.0_v4.4.1
+    depends_on: []


### PR DESCRIPTION
## Summary

Fixes Docker Compose override configuration for production deployment where PostgreSQL and Redis run outside of Docker containers.

## Changes

### Disabled External Services
- Added `db: !reset null` - Removes PostgreSQL database service definition (production uses external database)
- Added `redis: !reset null` - Removes Redis service definition (production uses external Redis)

### Removed Service Dependencies
- Set `depends_on: []` for `web`, `streaming`, and `sidekiq` services
- Prevents Docker from waiting for database/Redis containers that don't exist in production

## Technical Details

The `!reset null` syntax completely removes service definitions from the base `docker-compose.yml`, ensuring no database/Redis containers are created when running `docker compose up`.

This aligns with the fork's production deployment strategy where:
- PostgreSQL and Redis run as external services
- Only application services (`web`, `streaming`, `sidekiq`) run in containers
- Services connect to external database/Redis via environment variables in `.env.production`

## Testing

- [ ] Verify `docker compose up -d` starts only `web`, `streaming`, and `sidekiq` services
- [ ] Confirm no `db` or `redis` containers are created
- [ ] Verify services connect successfully to external database/Redis
